### PR TITLE
Fix ModelSim scripts and tests

### DIFF
--- a/tb/modelsim/scripts/spi_slave.do
+++ b/tb/modelsim/scripts/spi_slave.do
@@ -11,7 +11,8 @@ set LOGFILE [setup_logging $TB $HERE]
 if {![file isdirectory work]} { vlib work }
 vmap work work
 
-vlog -sv ../../../src/drivers/spi_slave_8.sv
+# Allow includes relative to project root (for future dependencies)
+vlog +incdir+../../../ -sv ../../../src/drivers/spi_slave_8.sv
 vlog -sv ../${TB}.sv
 
 vsim -c $TB -do "run -all; quit -f"

--- a/tb/modelsim/scripts/top_led_spi.do
+++ b/tb/modelsim/scripts/top_led_spi.do
@@ -16,7 +16,8 @@ if {![file isdirectory work]} { vlib work }
 vmap work work
 
 # Compila (ajuste a ordem se precisar)
-vlog -sv ../../../src/top/top_led_spi.sv
+# Include root to resolve `include"src/..."` directives
+vlog +incdir+../../../ -sv ../../../src/top/top_led_spi.sv
 vlog -sv ../../../src/drivers/spi_slave_8.sv
 vlog -sv ../../../src/drivers/spi_stream_bridge.sv
 vlog -sv ../../../src/services/led_service.sv

--- a/tb/modelsim/tb_spi_slave.sv
+++ b/tb/modelsim/tb_spi_slave.sv
@@ -56,7 +56,8 @@ module tb_spi_slave;
     spi_csn = 1'b1;
     @(posedge clk);
     @(posedge clk);
-    if (!rx_byte_valid) $fatal("RX byte not captured");
+      // Use explicit severity to avoid ModelSim argument warning
+      if (!rx_byte_valid) $fatal(1, "RX byte not captured");
     $display("MISO=%h", miso);
     $finish;
   end

--- a/tb/modelsim/verilator/test_tb_spi_slave.py
+++ b/tb/modelsim/verilator/test_tb_spi_slave.py
@@ -7,6 +7,7 @@ def test_tb_spi_slave():
     build.mkdir(parents=True, exist_ok=True)
     cmd = [
         "verilator", "-sv", "--binary",
+        f"-I{root}",
         str(root / "tb" / "modelsim" / "tb_spi_slave.sv"),
         str(root / "src" / "drivers" / "spi_slave_8.sv"),
         "--Mdir", str(build),

--- a/tb/modelsim/verilator/test_tb_top_led_spi.py
+++ b/tb/modelsim/verilator/test_tb_top_led_spi.py
@@ -26,6 +26,7 @@ def test_tb_top_led_spi():
     ]
     cmd = [
         "verilator", "-sv", "--binary",
+        f"-I{root}",
         str(root / "tb" / "modelsim" / "tb_top_led_spi.sv"),
         "--Mdir", str(build),
     ] + [str(s) for s in sources]


### PR DESCRIPTION
## Summary
- resolve include path errors in ModelSim script for top_led_spi
- make ModelSim scripts resilient to project-root includes
- update testbenches and Verilator tests for consistent logging and includes

## Testing
- `pytest -q tb/modelsim/verilator/test_tb_spi_slave.py tb/modelsim/verilator/test_tb_top_led_spi.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa245fec648326b344321432e22497