### PR TITLE
Handle unknown command in rx router and test

### DIFF
--- a/src/protocol/parsers/rx_router.sv
+++ b/src/protocol/parsers/rx_router.sv
@@ -53,8 +53,14 @@ module rx_router #(
       S_IDLE: if (in_stream.valid && in_stream.data == HDR_REQ) begin in_stream.ready = 1'b1; nx = S_CMD; end
       S_CMD:  if (in_stream.valid) begin in_stream.ready = 1'b1; req_cmd_valid = 1'b1; req_cmd_code = in_stream.data; nx = S_ROUTE; end
       S_ROUTE: if (allow_grant) begin
-        if (cmd_latched == CMD_LED_P) begin grant_led = 1'b1; nx = S_STREAM; end
-        else begin grant_led = 1'b1; nx = S_STREAM; end // placeholder para outros domínios
+        if (cmd_latched == CMD_LED_P) begin
+          grant_led = 1'b1;
+          nx        = S_STREAM;
+        end else begin
+          // Comando desconhecido: não concede grant e encerra frame
+          frame_done = 1'b1;
+          nx         = S_IDLE;
+        end
       end
       S_STREAM: begin
         grant_led        = 1'b1;

--- a/tb/verilator/test_invalid_cmd.py
+++ b/tb/verilator/test_invalid_cmd.py
@@ -1,0 +1,74 @@
+import sys
+import os
+from pathlib import Path
+sys.path.append(str(Path(__file__).parent))
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, Timer
+from cocotb_test.simulator import run
+
+from spi_master import spi_xfer
+
+@cocotb.test()
+async def drop_unknown_command(dut):
+    """Enviar comando desconhecido e verificar que o frame é descartado."""
+    cocotb.start_soon(Clock(dut.clk, 10, units="ns").start())
+    dut.rst_n.value = 0
+    dut.spi_sclk.value = 1
+    dut.spi_csn.value = 1
+    dut.spi_mosi.value = 0
+    await RisingEdge(dut.clk)
+    dut.rst_n.value = 1
+    await RisingEdge(dut.clk)
+
+    # Frame com comando inválido (0x40) e payload mínimo
+    req = [0xAA, 0x40, 0x00, 0x55]
+    await spi_xfer(dut, req)
+
+    # Espera pipeline
+    await Timer(100, units="ns")
+
+    # Leitura de resposta: espera zeros
+    rsp = await spi_xfer(dut, [0x00, 0x00])
+    assert rsp == [0x00, 0x00]
+
+    # LEDs devem permanecer desligados
+    assert int(dut.leds.value) == 0
+
+
+def test_invalid_cmd(tmp_path):
+    root = Path(__file__).resolve().parents[2]
+    src = root / "src"
+    verilog_sources = [
+        str(src / "top" / "top_led_spi.sv"),
+        str(src / "drivers" / "spi_slave_8.sv"),
+        str(src / "drivers" / "spi_stream_bridge.sv"),
+        str(src / "services" / "led_service.sv"),
+        str(src / "services" / "main_service.sv"),
+        str(src / "protocol" / "protocol_rx.sv"),
+        str(src / "protocol" / "protocol_tx.sv"),
+        str(src / "protocol" / "formatters" / "tx_formatter_led.sv"),
+        str(src / "protocol" / "formatters" / "tx_arbiter.sv"),
+        str(src / "protocol" / "parsers" / "rx_router.sv"),
+        str(src / "protocol" / "parsers" / "rx_parser_led.sv"),
+        str(src / "protocol" / "codecs" / "codec_led.sv"),
+        str(src / "protocol" / "interfaces" / "cmd_if_led.sv"),
+        str(src / "protocol" / "interfaces" / "stream_if.sv"),
+        str(src / "protocol" / "messages" / "msg_led.sv"),
+        str(src / "protocol" / "framings" / "framing_pkg.sv"),
+        str(src / "protocol" / "cmd" / "led_cmd_pkg.sv"),
+    ]
+    run(
+        simulator="verilator",
+        verilog_sources=verilog_sources,
+        toplevel="top_led_spi",
+        module=os.path.splitext(os.path.basename(__file__))[0],
+        includes=[str(root)],
+        compile_args=["-Wno-fatal"],
+        sim_build=str(Path(__file__).parent / "sim_build" / "invalid_cmd"),
+        parameters={"NUM_LEDS": 5},
+        python_search=[str(Path(__file__).parent)],
+        waves=True,
+        plus_args=["--trace"],
+    )


### PR DESCRIPTION
## Summary
- avoid granting unknown commands in RX router and terminate frame
- add cocotb test to verify invalid command is dropped

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa4c16f4fc8326be5a47ab0ea63a43