### PR TITLE
Add ModelSim testbench for SPI stream bridge

### DIFF
--- a/tb/modelsim/scripts/spi_stream_bridge.do
+++ b/tb/modelsim/scripts/spi_stream_bridge.do
@@ -1,0 +1,33 @@
+# spi_stream_bridge.do — script to run tb_spi_stream_bridge in ModelSim
+
+# Close any existing simulation
+quietly catch { quit -sim }
+
+# Directory containing this .do
+set HERE [file normalize [file dirname [info script]]]
+cd $HERE
+
+# Logging utilities
+do [file join $HERE utils utils_logging.do]
+
+# Testbench and log
+set TB "tb_spi_stream_bridge"
+set LOGFILE [setup_logging $TB $HERE]
+
+# Include root for `include "src/..."`
+set INCARGS "+incdir+../../../"
+
+# Prepare work library
+if {![file isdirectory work]} { vlib work }
+vmap work work
+
+# Compilation
+vlog $INCARGS -sv ../../../src/protocol/interfaces/stream_if.sv
+vlog $INCARGS -sv ../../../src/drivers/spi_stream_bridge.sv
+vlog $INCARGS -sv ../${TB}.sv
+
+# Simulation
+vsim -c $TB -do "run -all"
+
+# Finish logging
+finish_logging

--- a/tb/modelsim/scripts/spi_stream_bridge_waves.do
+++ b/tb/modelsim/scripts/spi_stream_bridge_waves.do
@@ -1,0 +1,34 @@
+# Waveform setup for tb_spi_stream_bridge
+
+# Testbench clock
+add wave -divider "TB"
+add wave -radix binary sim:/tb_spi_stream_bridge/clk
+add wave -radix binary sim:/tb_spi_stream_bridge/rst_n
+
+# RX byte side
+add wave -divider "RX byte"
+add wave -radix hex sim:/tb_spi_stream_bridge/rx_byte
+add wave -radix binary sim:/tb_spi_stream_bridge/rx_byte_valid
+add wave -radix binary sim:/tb_spi_stream_bridge/rx_byte_ready
+
+# RX stream interface
+add wave -divider "RX stream"
+add wave -radix hex sim:/tb_spi_stream_bridge/rx_stream_if/data
+add wave -radix binary sim:/tb_spi_stream_bridge/rx_stream_if/valid
+add wave -radix binary sim:/tb_spi_stream_bridge/rx_stream_if/ready
+
+# TX stream interface
+add wave -divider "TX stream"
+add wave -radix hex sim:/tb_spi_stream_bridge/tx_stream_if/data
+add wave -radix binary sim:/tb_spi_stream_bridge/tx_stream_if/valid
+add wave -radix binary sim:/tb_spi_stream_bridge/tx_stream_if/ready
+
+# TX byte side
+add wave -divider "TX byte"
+add wave -radix hex sim:/tb_spi_stream_bridge/tx_byte
+add wave -radix binary sim:/tb_spi_stream_bridge/tx_byte_valid
+add wave -radix binary sim:/tb_spi_stream_bridge/tx_byte_ready
+
+# Internal signals
+add wave -divider "DUT"
+add wave -radix binary sim:/tb_spi_stream_bridge/dut/*

--- a/tb/modelsim/tb_spi_stream_bridge.sv
+++ b/tb/modelsim/tb_spi_stream_bridge.sv
@@ -1,0 +1,73 @@
+`timescale 1ns/1ps
+`include "src/protocol/interfaces/stream_if.sv"
+
+module tb_spi_stream_bridge;
+  // Clock and reset (though design is combinational, interfaces expect them)
+  logic clk = 0;
+  always #5 clk = ~clk;
+  logic rst_n = 1;
+
+  // Byte-side handshake
+  logic        rx_byte_valid;
+  logic [7:0]  rx_byte;
+  logic        rx_byte_ready;
+  logic        tx_byte_valid;
+  logic [7:0]  tx_byte;
+  logic        tx_byte_ready;
+
+  // Stream interfaces
+  stream_if #(8) rx_stream_if(clk, rst_n);
+  stream_if #(8) tx_stream_if(clk, rst_n);
+
+  // DUT
+  spi_stream_bridge dut(
+    .clk(clk),
+    .rst_n(rst_n),
+    .rx_byte_valid(rx_byte_valid),
+    .rx_byte(rx_byte),
+    .rx_byte_ready(rx_byte_ready),
+    .tx_byte_valid(tx_byte_valid),
+    .tx_byte(tx_byte),
+    .tx_byte_ready(tx_byte_ready),
+    .rx_stream(rx_stream_if.producer),
+    .tx_stream(tx_stream_if.consumer)
+  );
+
+  // Test sequence
+  initial begin
+    // initialise
+    rx_byte_valid = 0;
+    rx_byte = '0;
+    tx_stream_if.valid = 0;
+    tx_stream_if.data = '0;
+    tx_byte_ready = 0;
+    rx_stream_if.ready = 0;
+
+    // wait some cycles
+    repeat (2) @(posedge clk);
+
+    // RX path: byte -> stream
+    rx_byte = 8'hA5;
+    rx_byte_valid = 1;
+    rx_stream_if.ready = 1;
+    @(posedge clk);
+    assert(rx_byte_ready) else $fatal("rx_byte_ready not asserted");
+    assert(rx_stream_if.valid && rx_stream_if.data == 8'hA5)
+      else $fatal("RX stream mismatch");
+    rx_byte_valid = 0;
+    rx_stream_if.ready = 0;
+
+    // TX path: stream -> byte
+    tx_stream_if.data = 8'h3C;
+    tx_stream_if.valid = 1;
+    tx_byte_ready = 1;
+    @(posedge clk);
+    assert(tx_byte_valid && tx_byte == 8'h3C)
+      else $fatal("TX byte mismatch");
+    tx_stream_if.valid = 0;
+    tx_byte_ready = 0;
+
+    $display("tb_spi_stream_bridge passed");
+    $finish;
+  end
+endmodule

--- a/tb/verilator/spi_stream_bridge_tb.sv
+++ b/tb/verilator/spi_stream_bridge_tb.sv
@@ -1,0 +1,26 @@
+`include "src/protocol/interfaces/stream_if.sv"
+module spi_stream_bridge_tb(
+  input  logic clk,
+  input  logic rst_n,
+  input  logic        rx_byte_valid,
+  input  logic [7:0]  rx_byte,
+  output logic        rx_byte_ready,
+  output logic        tx_byte_valid,
+  output logic [7:0]  tx_byte,
+  input  logic        tx_byte_ready
+);
+  stream_if #(8) rx_stream_if(clk, rst_n);
+  stream_if #(8) tx_stream_if(clk, rst_n);
+  spi_stream_bridge dut(
+    .clk(clk),
+    .rst_n(rst_n),
+    .rx_byte_valid(rx_byte_valid),
+    .rx_byte(rx_byte),
+    .rx_byte_ready(rx_byte_ready),
+    .tx_byte_valid(tx_byte_valid),
+    .tx_byte(tx_byte),
+    .tx_byte_ready(tx_byte_ready),
+    .rx_stream(rx_stream_if.producer),
+    .tx_stream(tx_stream_if.consumer)
+  );
+endmodule

--- a/tb/verilator/test_spi_stream_bridge.py
+++ b/tb/verilator/test_spi_stream_bridge.py
@@ -1,0 +1,65 @@
+import sys, os
+from pathlib import Path
+sys.path.append(str(Path(__file__).parent))
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge
+from cocotb_test.simulator import run
+
+@cocotb.test()
+async def stream_bridge_basic(dut):
+    cocotb.start_soon(Clock(dut.clk, 10, units="ns").start())
+    dut.rst_n.value = 0
+    dut.rx_byte_valid.value = 0
+    dut.rx_byte.value = 0
+    dut.tx_byte_ready.value = 0
+    dut.rx_stream_if.ready.value = 0
+    dut.tx_stream_if.valid.value = 0
+    await RisingEdge(dut.clk)
+    dut.rst_n.value = 1
+    await RisingEdge(dut.clk)
+
+    # Test RX path: byte -> stream
+    dut.rx_stream_if.ready.value = 1
+    dut.rx_byte.value = 0x3C
+    dut.rx_byte_valid.value = 1
+    await RisingEdge(dut.clk)
+    assert int(dut.rx_stream_if.valid.value) == 1
+    assert int(dut.rx_stream_if.data.value) == 0x3C
+    assert int(dut.rx_byte_ready.value) == 1
+    dut.rx_byte_valid.value = 0
+    dut.rx_stream_if.ready.value = 0
+    await RisingEdge(dut.clk)
+
+    # Test TX path: stream -> byte
+    dut.tx_stream_if.valid.value = 1
+    dut.tx_stream_if.data.value = 0xA5
+    dut.tx_byte_ready.value = 1
+    await RisingEdge(dut.clk)
+    assert int(dut.tx_byte_valid.value) == 1
+    assert int(dut.tx_byte.value) == 0xA5
+    assert int(dut.tx_stream_if.ready.value) == 1
+    dut.tx_stream_if.valid.value = 0
+    dut.tx_byte_ready.value = 0
+    await RisingEdge(dut.clk)
+
+
+def test_spi_stream_bridge(tmp_path):
+    root = Path(__file__).resolve().parents[2]
+    verilog_sources = [
+        str(root / "src" / "drivers" / "spi_stream_bridge.sv"),
+        str(root / "tb" / "verilator" / "spi_stream_bridge_tb.sv"),
+    ]
+    run(
+        simulator="verilator",
+        verilog_sources=verilog_sources,
+        toplevel="spi_stream_bridge_tb",
+        module=os.path.splitext(os.path.basename(__file__))[0],
+        includes=[str(root)],
+        compile_args=["-Wno-fatal"],
+        sim_build=str(Path(__file__).parent / "sim_build" / "spi_stream_bridge"),
+        python_search=[str(Path(__file__).parent)],
+        waves=True,
+        plus_args=["--trace"],
+    )


### PR DESCRIPTION
## Summary
- add self-checking ModelSim testbench for spi_stream_bridge
- provide corresponding simulation and waveform scripts

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68acaa6b6b1c8326a8ab00e25d25b001